### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
             "ElgentosDutchEmailTemplates\\": "src/"
         }
     },
-    "suggests": {
-        "frosh/frosh-platform-template-mail": "Store mail templates in theme"
-    },
     "extra": {
         "shopware-plugin-class": "ElgentosDutchEmailTemplates\\ElgentosDutchEmailTemplates",
         "copyright": "(c) by Elgentos",


### PR DESCRIPTION
Hey, tnx for your plugin!

The "suggests" in the composer.json (which I fully understand why you've added it, it's great!) causes a error while loading your plugin with `bin/console plugin:refresh`.
![image](https://user-images.githubusercontent.com/7152234/124647933-e26a2580-de96-11eb-8aad-7fd2b0b740e4.png)
This plugin is not showing in the plugins-list due to that error.

Keep up the good work!